### PR TITLE
Changes the implementation to use an iframe to avoid conflicts with A…

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 An ember wrapper for the [monaco-editor](https://github.com/Microsoft/monaco-editor) (vs code's editor). From the monaco-editor's README "The Monaco Editor is the code editor that powers [VS Code](https://github.com/Microsoft/vscode), a good page describing the code editor's features is [here](https://code.visualstudio.com/docs/editor/editingevolved)".
 
 ```
-{{monaco-editor language="javascript" value=code
+{{monaco-editor language="javascript" code=code
   onChange=(action codeChanged)}}
 ```
 

--- a/addon/components/monaco-editor.js
+++ b/addon/components/monaco-editor.js
@@ -1,42 +1,60 @@
-/* globals monaco */
-
 import Ember from 'ember';
 import layout from '../templates/components/monaco-editor';
-
-let monacoLoadingPromise;
+import getFrameById from 'ember-monaco-editor/utils/get-frame-by-id';
 
 export default Ember.Component.extend({
   layout,
+  classNames: ['monaco-editor'],
   init () {
     this._super(...arguments);
-    monacoLoadingPromise = monacoLoadingPromise || this._loadScript('/vs/loader.js');
-    monacoLoadingPromise.then(()=>{
-      window.require(['vs/editor/editor.main'], () => {
-        if(typeof monaco !== "undefined") {
-          // TODO: change this to use this.$().element or similar
-          this.editor = monaco.editor.create(document.getElementById('container'), {
-            value: this.get('code'),
-            language: this.get('language')
+    const subscription = event=> {
+      // Ignore messages not coming from this iframe
+      if (event.source === this.get('frame') && event.data && event.data.updatedCode) {
+        this.attrs.onChange(event.data.updatedCode);
+      }
+    };
+    this.set('_subscription', subscription);
+    window.addEventListener('message', subscription);
+  },
+  didInsertElement () {
+    this._super(...arguments);
+    const frame = getFrameById(this.get('elementId'));
+    const frameDoc = frame.document;
+    this.set('frame', frame);
+    frameDoc.open();
+    frameDoc.write(`
+      <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+      <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en" id="print-modal-content">
+      <head>
+        <script src="/vs/loader.js"></script>
+        <script>
+          window.require.config({ paths: { 'vs': '/vs' }});
+          window.require(['vs/editor/editor.main'], function () {
+            if (typeof monaco !== "undefined") {
+              var editor = monaco.editor.create(document.getElementById('monaco-editor-wrapper'), {
+                value: '${this.get('code')}',
+                language: '${this.get('language')}'
+              });
+              var origin = window.location.origin;
+              // TODO: when the code is autocompleted we don't get this even firing
+              // For example type a single ', the editor will autocomplete '' we only get
+              // the first ', not ''
+              editor.onDidChangeModelContent(function () {
+                window.top.postMessage({updatedCode: event.target.value}, origin);
+              });
+            }
           });
-          this.editor.onDidChangeModelContent(()=> {
-            this.sendAction('onChange', event.target.value);
-          });
-        }
-      });
-    });
+          </script>
+      </head>
+      <body>
+        <div id="monaco-editor-wrapper" style="width:800px;height:600px;border:1px solid grey"></div>
+      </body>
+      </html>
+    `);
+    frame.close();
   },
   willDestroyElement () {
-    if (this.editor) {
-      this.editor.destroy();
-    }
-  },
-  _loadScript (url) {
-    var scriptElement = Ember.$("<script>").prop({src: url, async: true});
-    let promise = new Ember.RSVP.Promise((resolve, reject)=>{
-      scriptElement.one('load', ()=> Ember.run(null, resolve));
-      scriptElement.one('error', (evt)=> Ember.run(null, reject, evt));
-    });
-    document.head.appendChild(scriptElement[0]);
-    return promise;
-  },
+    this._super(...arguments);
+    window.removeEventListener('message', this.get('_subscription'));
+  }
 });

--- a/addon/templates/components/monaco-editor.hbs
+++ b/addon/templates/components/monaco-editor.hbs
@@ -1,2 +1,1 @@
-<div id="container" style="width:800px;height:600px;border:1px solid grey"></div>
-{{yield}}
+<iframe scrolling="no" border="0" width="820px" height="620px" frameborder="0" name={{elementId}}></iframe>

--- a/addon/utils/get-frame-by-id.js
+++ b/addon/utils/get-frame-by-id.js
@@ -1,0 +1,9 @@
+export default function getFrameById(id) {
+  for (var i = 0; i < window.frames.length; i++) {
+    try {
+      if (window.frames[i].name === id) {
+          return window.frames[i];
+      }
+    } catch(err) {}
+  }
+}

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,4 +1,4 @@
-{{monaco-editor language="javascript" value=code
+{{monaco-editor language="javascript" code=code
   onChange=(action "codeChanged")}}
 
 {{#link-to "blog"}}Blog{{/link-to}}

--- a/tests/integration/components/monaco-editor-test.js
+++ b/tests/integration/components/monaco-editor-test.js
@@ -1,24 +1,34 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import Ember from 'ember';
+import getFrameById from 'ember-monaco-editor/utils/get-frame-by-id';
+import wait from 'ember-test-helpers/wait';
 
 moduleForComponent('monaco-editor', 'Integration | Component | monaco editor', {
   integration: true
 });
 
-test('it renders', function(assert) {
-  // Set any properties with this.set('myProperty', 'value');
-  // Handle any actions with this.on('myAction', function(val) { ... });
+test('it renders', function (assert) {
+  this.set('code', 'myFunction().property;');
+  let changedCode;
+  this.set('codeChanged', (newCode)=>changedCode = newCode);
+  this.render(hbs`{{monaco-editor language="javascript" code=code
+    onChange=(action codeChanged)}}`);
 
-  this.render(hbs`{{monaco-editor}}`);
-
-  assert.equal(this.$().text().trim(), '');
-
-  // Template block usage:
-  this.render(hbs`
-    {{#monaco-editor}}
-      template block text
-    {{/monaco-editor}}
-  `);
-
-  assert.equal(this.$().text().trim(), 'template block text');
+  Ember.run.later(()=> {
+    // NOTE: introduces an artifical wait to get a chance
+    // for the editor to boot. This isn't promisey so ember won't
+    // wait by default. We may be able to add an event and
+    // promisify this....
+  }, 500);
+  return wait().then(()=>{
+    const frame = getFrameById(this.$('.monaco-editor').attr('id'));
+    const $wrapper = $(frame.document.getElementById('monaco-editor-wrapper'));
+    const $textArea = $wrapper.find('textArea');
+    // NOTE: these are implementation details of the monaco-editor,
+    // it's fragile, but leaving it for now. If it brakes, just move away from this
+    // approach
+    assert.equal($textArea.val(), this.get('code'));
+    // TODO: test the action firing. simply setting the value in the textarea doesnt work
+  });
 });


### PR DESCRIPTION
This switches the strategy to use an iframe to avoid the conflicts with AMD. The API remains the same, so consumers can start using it and once we fix the AMD conflicts we will switch it without breaking apps. 
